### PR TITLE
Fix edge cases where decimal representation is chosen instead of a shorter exponential representation.

### DIFF
--- a/Tests/TestGrisu.cs
+++ b/Tests/TestGrisu.cs
@@ -87,41 +87,42 @@ namespace Tests
                 Console.WriteLine(writer.ToString());
         }
 
-        [Test]
-        public void TestDoubleToString()
-        {
-            CheckDoubleToStringEquals("0", 0.0);
-            CheckDoubleToStringEquals("12345", 12345.0);
-            CheckDoubleToStringEquals("1.2345e27", 12345e23);
-            CheckDoubleToStringEquals("1e21", 1e21);
-            CheckDoubleToStringEquals("1e20", 1e20);
-            CheckDoubleToStringEquals("1.1111111111111111e20", 111111111111111111111.0);
-            CheckDoubleToStringEquals("1.1111111111111111e21", 1111111111111111111111.0);
-            CheckDoubleToStringEquals("1.1111111111111111e22", 11111111111111111111111.0);
-            CheckDoubleToStringEquals("-1e-5", -0.00001);
-            CheckDoubleToStringEquals("-1e-6", -0.000001);
-            CheckDoubleToStringEquals("-1e-7", -0.0000001);
-            CheckDoubleToStringEquals("0", -0.0);
-            CheckDoubleToStringEquals("0.1", 0.1);
-            CheckDoubleToStringEquals("0.01", 0.01);
-            CheckDoubleToStringEquals("1", 1.0);
-            CheckDoubleToStringEquals("10", 10.0);
-            CheckDoubleToStringEquals("1100", 1100.0);
-            CheckDoubleToStringEquals("1122", 1122.0);
-            CheckDoubleToStringEquals("1e4", 10000.0);
-            CheckDoubleToStringEquals("11100", 11100.0);
-            CheckDoubleToStringEquals("1e5", 100000.0);
-            CheckDoubleToStringEquals("1e-6", 0.000001);
-            CheckDoubleToStringEquals("1e-7", 0.0000001);
-            CheckDoubleToStringEquals("1e20", 100000000000000000000.0);
-            CheckDoubleToStringEquals("Infinity", double.PositiveInfinity);
-            CheckDoubleToStringEquals("-Infinity", double.NegativeInfinity);
-            CheckDoubleToStringEquals("NaN", double.NaN);
-            CheckDoubleToStringEquals("NaN", -double.NaN);
-            CheckDoubleToStringEquals("3.5844466002796428E+298", 3.5844466002796428e+298);
-        }
-
-        private void CheckDoubleToStringEquals(string expected, double value)
+        [TestCase("0", 0.0)]
+        [TestCase("12345", 12345.0)]
+        [TestCase("1.2345e27", 12345e23)]
+        [TestCase("1e21", 1e21)]
+        [TestCase("1e20", 1e20)]
+        [TestCase("1.1111111111111111e20", 111111111111111111111.0)]
+        [TestCase("1.1111111111111111e21", 1111111111111111111111.0)]
+        [TestCase("1.1111111111111111e22", 11111111111111111111111.0)]
+        [TestCase("-1e-5", -0.00001)]
+        [TestCase("-1e-6", -0.000001)]
+        [TestCase("-1e-7", -0.0000001)]
+        [TestCase("0", -0.0)]
+        [TestCase("0.1", 0.1)]
+        [TestCase("0.01", 0.01)]
+        [TestCase("1", 1.0)]
+        [TestCase("10", 10.0)]
+        [TestCase("1100", 1100.0)]
+        [TestCase("1122", 1122.0)]
+        [TestCase("1e4", 10000.0)]
+        [TestCase("11100", 11100.0)]
+        [TestCase("1e5", 100000.0)]
+        [TestCase("1e-6", 0.000001)]
+        [TestCase("1e-7", 0.0000001)]
+        [TestCase("1e20", 100000000000000000000.0)]
+        [TestCase("Infinity", double.PositiveInfinity)]
+        [TestCase("-Infinity", double.NegativeInfinity)]
+        [TestCase("NaN", double.NaN)]
+        [TestCase("NaN", -double.NaN)]
+        [TestCase("3.5844466002796428E+298", 3.5844466002796428e+298)]
+        [TestCase("-5.401035826582183e-4", -0.0005401035826582183)]
+        [TestCase("5.401035826582183e-4", 0.0005401035826582183)]
+        [TestCase("5401.035826582183", 5401.035826582183)]
+        [TestCase("-5401.035826582183", -5401.035826582183)]
+        [TestCase("-0.0015677654444036897", -0.0015677654444036897)]
+        [TestCase("-3.3200274383931173e-4", -3.3200274383931173e-4)]
+        public void TestDoubleToString(string expected, double value)
         {
             StringWriter writer = new StringWriter();
             Grisu.DoubleToString(value, writer);
@@ -142,7 +143,7 @@ namespace Tests
             }
 
             [TestFixtureTearDown]
-            public void TearDown()
+            public void TestFixtureTearDown()
             {
                 Thread.CurrentThread.CurrentCulture = m_originalCulture;
             }

--- a/grisu.net/Grisu.cs
+++ b/grisu.net/Grisu.cs
@@ -73,19 +73,19 @@ namespace GrisuDotNet
             }
             else if (decimal_point >= decimal_rep_length)
             {
-                decimalRepLength += decimal_point - decimal_rep_length + 1;
+                decimalRepLength += decimal_point - decimal_rep_length;
             }
 
             int exponent = decimal_point - 1;
             int absExponent = Math.Abs(exponent);
-            int exponentRepLength = decimal_rep_length + 3;
+            int exponentRepLength = decimal_rep_length + 2; // one for 'e' and one for first exponent digit
             if (exponent < 0)
-                ++exponentRepLength;
+                ++exponentRepLength; // additional one for '-'
             if (absExponent >= 10)
             {
-                ++exponentRepLength;
+                ++exponentRepLength; // additional one for second exponent digit
                 if (absExponent >= 100)
-                    ++exponentRepLength;
+                    ++exponentRepLength; // additional one for third exponent digit
             }
 
             if (decimalRepLength <= exponentRepLength)


### PR DESCRIPTION
The logic for calculating the lengths of the two representations was incorrect.

For example:

`-0.0005401035826582183`  (previously written instead of)
`-5.401035826582183e-4`  (shorter)